### PR TITLE
Add Linux build preset and dependency docs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,36 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 16, "patch": 0},
+  "configurePresets": [
+    {
+      "name": "linux-debug",
+      "displayName": "Linux Debug",
+      "description": "Debug build using Ninja and system compilers",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-release",
+      "displayName": "Linux Release",
+      "description": "Release build using Ninja and system compilers",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "linux-debug",
+      "configurePreset": "linux-debug"
+    },
+    {
+      "name": "linux-release",
+      "configurePreset": "linux-release"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Developed at the University of Texas at Austin in Dr. Andrew Dunn's [_Functional
     * [Setup Qt Project](#setup-qt-project)
     * [Building for Release](#building-for-release)
 * [Using the Speckle Software](#using-the-speckle-software)
+* [Linux Development](#linux-development)
 
 ## Developing the Speckle Software
 
@@ -117,3 +118,29 @@ git push origin --tags
 ## Using the Speckle Software
 
 See the [Speckle Software Documentation](https://utfoil.github.io/speckle-software/) website. Source located on [`docs`](https://github.com/UTFOIL/speckle-software/tree/docs) branch.
+
+## Linux Development
+
+Experimental support for building on Linux is available using CMake with Qt6 and OpenCV.
+
+### Install Dependencies
+
+On Ubuntu 22.04 or similar:
+
+```bash
+sudo apt update
+sudo apt install build-essential cmake ninja-build qt6-base-dev qt6-tools-dev libopencv-dev
+```
+
+Basler's Pylon SDK is optional but required for camera support. Download and install it from the [Basler website](https://www.baslerweb.com/en/products/software/).
+
+### Configure and Build
+
+Use the provided CMake presets:
+
+```bash
+cmake --preset linux-debug
+cmake --build --preset linux-debug
+```
+
+Replace `linux-debug` with `linux-release` for an optimized build.

--- a/todo.md
+++ b/todo.md
@@ -16,7 +16,6 @@
 - [ ] Optimize naive `convolve`, `blur`, and resize or move to OpenCV equivalents
 - [ ] Add unit/perf tests for speckle computation paths (8-bit, 16-bit, temporal)
 - [ ] CI workflow (Linux) to build and run basic tests
-- [ ] Document Linux dependencies and add CMake presets
 - [ ] Optional Windows build with Qt6/OpenCV via vcpkg
 - [ ] UI: Replace About dialog CImg version with shim label or remove
 - [ ] UI: Add option to toggle OpenCV/Qt backends if both are present
@@ -29,3 +28,4 @@
 ## Done
 - [x] Add `TASKS.md`
 - [x] Add `LESSONS_LEARNED.md`
+- [x] Document Linux dependencies and add CMake presets


### PR DESCRIPTION
## Summary
- document Linux dependencies and usage of CMake presets
- add `CMakePresets.json` with `linux-debug` and `linux-release`
- mark todo item for documenting Linux dependencies as complete

## Testing
- `cmake --list-presets`
- `cmake --preset linux-debug` *(fails: FindQt6.cmake not found)*
- `cmake --build --preset linux-debug` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e12d38988327b6796b6697e9f64a

## Summary by Sourcery

Add Linux build presets and update project documentation to include dependency setup and build instructions for Linux

New Features:
- Add CMake presets for Linux debug and release builds

Build:
- Include CMakePresets.json defining linux-debug and linux-release configurations

Documentation:
- Add Linux Development section to the README with dependency installation and build instructions

Chores:
- Mark the Linux dependencies and presets documentation task as completed in todo.md